### PR TITLE
Added bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,24 @@
+{
+  "name": "leaflet.wms",
+  "main": "leaflet.wms.js",
+  "version": "0.0.1",
+  "homepage": "http://heigeo.github.io/leaflet.wms/",
+  "description": "A Leaflet plugin for working with Web Map services, providing: single-tile/untiled/nontiled layers, shared WMS sources, and GetFeatureInfo-powered identify",
+  "keywords": [
+    "javascript",
+    "leaflet",
+    "wms"
+  ],
+  "dependencies": [
+    "leaflet": "lib/leaflet.js"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "app/bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/bower.json
+++ b/bower.json
@@ -9,9 +9,9 @@
     "leaflet",
     "wms"
   ],
-  "dependencies": [
+  "dependencies": {
     "leaflet": "lib/leaflet.js"
-  ],
+  },
   "license": "MIT",
   "ignore": [
     "**/.*",

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "wms"
   ],
   "dependencies": {
-   "leaflet": "0.8-dev"
+   "leaflet": "#master"
   },
   "license": "MIT",
   "ignore": [

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "wms"
   ],
   "dependencies": {
-    "leaflet": "lib/leaflet.js"
+   "leaflet": "0.8-dev"
   },
   "license": "MIT",
   "ignore": [


### PR DESCRIPTION
A bower.json file to make easy the library to be used in bower based projects. To use it:

bower install git://github.com/heigeo/leaflet.wms.git#gh-pages

If you want to release your library to the bower repository execute this:

bower register leaflet.wms git://github.com/heigeo/leaflet.wms.git

You need to create a "SemVerTag" (Vx.y.z) that has to be equals as the version in the bower.json 
