### PR TITLE
Round X/Y Co-Ords in infoParams. (Browser Fix)

### DIFF
--- a/leaflet.wms.js
+++ b/leaflet.wms.js
@@ -164,8 +164,8 @@ wms.Source = L.Layer.extend({
         var infoParams = {
             'request': 'GetFeatureInfo',
             'query_layers': layers.join(','),
-            'X': point.x,
-            'Y': point.y
+            'X': Math.round(point.x),
+            'Y': Math.round(point.y)
         };
         return L.extend({}, wmsParams, infoParams);
     },


### PR DESCRIPTION
When querying a layer in Internet Explorer - the WMS will throw an "X and Y incorrectly specified" error in the parse response. This error seems only occur in IE specifically. Investigating the X/Y parameters passed - they appear to be decimal values where integers are expected.

The fix for this is to Math.round() the X and Y values in infoParams so that the decimal value is removed by rounding the value to the closest real number before it is passed as a request when querying.

This should (I think) solve the issue found here: #17
