### PR TITLE
Pass layerName in wms.layer() factory

### DIFF
--- a/src/leaflet.wms.js
+++ b/src/leaflet.wms.js
@@ -275,8 +275,8 @@ wms.Layer = L.Layer.extend({
     }
 });
 
-wms.layer = function(source, options) {
-    return new wms.Layer(source, options);
+wms.layer = function(source, layerName, options) {
+    return new wms.Layer(source, layerName, options);
 };
 
 // Cache of sources for use with wms.Layer auto-source option


### PR DESCRIPTION
I wasn't able to pass options into `L.WMS.Layer` - is this patch required?
If so, what needs to be done to `L.WMS.Source.getLayer()`, if anything?

Apologies if I am misunderstanding how this works.