### PR TITLE
remove source from map properly, symmetric to addition.

### DIFF
--- a/src/leaflet.wms.js
+++ b/src/leaflet.wms.js
@@ -80,6 +80,9 @@ wms.Source = L.Layer.extend({
         this.refreshOverlay();
     },
 
+    'onRemove': function() {
+    },
+
     'getEvents': function() {
         if (this.options.identify) {
             return {'click': this.identify};
@@ -263,6 +266,7 @@ wms.Layer = L.Layer.extend({
     },
     'onRemove': function() {
         this._source.removeSubLayer(this._name);
+        this._source.removeFrom(this._map);
     },
     'setOpacity': function(opacity) {
         this._source.setOpacity(opacity);


### PR DESCRIPTION
`wms.Layer.onAdd` is adding `this._source` to `this._map`, but is not removed symmetrically on `onRemove`.

The consequence is that the attribution is never removed if the layer is removed/managed using `L.Control.Layers`. If you change to different layers that use `wms.Layer`, the attributions are appended (never removed), even if you remove the layer.